### PR TITLE
Install fontconfig package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,18 @@ WORKDIR /
 COPY --from=build /usr/share/keyrings/microsoft-prod.gpg /usr/share/keyrings/microsoft-prod.gpg
 COPY --from=build /etc/apt/sources.list.d/ /etc/apt/sources.list.d
 
+# Install fontconfig
+
+# renovate: datasource=repology depName=debian_12/fontconfig versioning=deb
+ENV FONTCONFIG_VERSION=2.14.1-4
+
+RUN apt-get update -y && \
+  # Install necessary dependencies
+  apt-get install -y --no-install-recommends fontconfig=${FONTCONFIG_VERSION} && \
+  # Clean up
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
 # Install .NET 9
 
 # renovate: datasource=github-tags depName=dotnet/sdk extractVersion=^v(?<version>.*)$


### PR DESCRIPTION
Installs the `fontconfig` package.
This package, amongst others that are already part of the base image, are required if you want to use things like `SkiaSharp`.